### PR TITLE
Rails 4.2

### DIFF
--- a/cancannible.gemspec
+++ b/cancannible.gemspec
@@ -18,12 +18,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", "4.2.0.beta2"
-  spec.add_runtime_dependency "activemodel", "~> 4.2.0.beta2"
-  spec.add_runtime_dependency "cancan", "~> 1.6"
+  spec.add_runtime_dependency "activesupport", "4.2.0.rc3"
+  spec.add_runtime_dependency "activemodel", "~> 4.2.0.rc3"
+  # spec.add_runtime_dependency "cancan", "~> 1.6"
+  spec.add_runtime_dependency "cancancan", "~> 1.9"
 
-  spec.add_development_dependency "activerecord", "4.2.0.beta2"
-  spec.add_development_dependency "arel", "6.0.0.beta2"
+  spec.add_development_dependency "activerecord", "4.2.0.rc3"
+  # spec.add_development_dependency "arel", "6.0.0.beta2"
   spec.add_development_dependency "sqlite3", "~> 1.3"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/cancannible.gemspec
+++ b/cancannible.gemspec
@@ -18,11 +18,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", "~> 3.2"
-  spec.add_runtime_dependency "activemodel", "~> 3.2"
+  spec.add_runtime_dependency "activesupport", "4.2.0.beta2"
+  spec.add_runtime_dependency "activemodel", "~> 4.2.0.beta2"
   spec.add_runtime_dependency "cancan", "~> 1.6"
 
-  spec.add_development_dependency "activerecord", "~> 3.2"
+  spec.add_development_dependency "activerecord", "4.2.0.beta2"
+  spec.add_development_dependency "arel", "6.0.0.beta2"
   spec.add_development_dependency "sqlite3", "~> 1.3"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/cancannible/grantee.rb
+++ b/lib/cancannible/grantee.rb
@@ -26,8 +26,14 @@ module Cancannible::Grantee
         permission = find_by_asserted_and_ability_and_resource_id_and_resource_type(
           asserted, ability, resource_id, resource_type)
         unless permission
-          permission = find_or_initialize_by_asserted_and_ability_and_resource_id_and_resource_type(
-            !asserted, ability, resource_id, resource_type)
+          # permission = find_or_initialize_by_asserted_and_ability_and_resource_id_and_resource_type(
+          #   !asserted, ability, resource_id, resource_type)
+          permission = find_or_initialize_by(
+            asserted: !asserted,
+            ability: ability,
+            resource_id: resource_id,
+            resource_type: resource_type
+          )
           permission.asserted = asserted
           permission.save!
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'sqlite3'
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each {|f| require f}
 
 RSpec.configure do |config|
   config.before do


### PR DESCRIPTION
All tests green with Rails 4.2.0-beta2 and a nasty Arel fix that plagues Rails 4.2 testers. **Not** tested within a real application though.

Rails 4 deprecated and Rails 4.2 enforces the use of `find_or_initialize_by` only with a hash parameter, so that was the only change made.

I think this change makes it compatible with Rails 4 in general (not fully tested). It certainly makes it _incompatible_ with Rails 3.2 though, that might need another round of fixing. What are your thoughts about Rails 4 compatibility?

(Sorry for the messy commits)
